### PR TITLE
ScrollPosition minScrollExtent null check error

### DIFF
--- a/lib/infinite_carousel.dart
+++ b/lib/infinite_carousel.dart
@@ -344,7 +344,8 @@ class InfiniteExtentMetrics extends FixedScrollMetrics {
     int? itemIndex,
   }) {
     return InfiniteExtentMetrics(
-      minScrollExtent: minScrollExtent ?? this.minScrollExtent,
+      minScrollExtent: minScrollExtent ??
+          (this.hasContentDimensions ? this.minScrollExtent : 0.0),
       maxScrollExtent: maxScrollExtent ?? this.maxScrollExtent,
       pixels: pixels ?? this.pixels,
       viewportDimension: viewportDimension ?? this.viewportDimension,

--- a/lib/infinite_carousel.dart
+++ b/lib/infinite_carousel.dart
@@ -433,7 +433,8 @@ class _InfiniteScrollPosition extends ScrollPositionWithSingleContext
     return _getItemFromOffset(
       offset: pixels,
       itemExtent: itemExtent,
-      minScrollExtent: minScrollExtent,
+      // 解决 Null check operator used on a null value
+      minScrollExtent: this.hasContentDimensions ? minScrollExtent : 0.0,
       maxScrollExtent: maxScrollExtent,
     );
   }
@@ -448,7 +449,9 @@ class _InfiniteScrollPosition extends ScrollPositionWithSingleContext
     int? itemIndex,
   }) {
     return InfiniteExtentMetrics(
-      minScrollExtent: minScrollExtent ?? this.minScrollExtent,
+      // 解决 Null check operator used on a null value
+      minScrollExtent: minScrollExtent ??
+          (this.hasContentDimensions ? this.minScrollExtent : 0.0),
       maxScrollExtent: maxScrollExtent ?? this.maxScrollExtent,
       pixels: pixels ?? this.pixels,
       viewportDimension: viewportDimension ?? this.viewportDimension,

--- a/lib/infinite_carousel.dart
+++ b/lib/infinite_carousel.dart
@@ -344,6 +344,7 @@ class InfiniteExtentMetrics extends FixedScrollMetrics {
     int? itemIndex,
   }) {
     return InfiniteExtentMetrics(
+      // 解决 Null check operator used on a null value
       minScrollExtent: minScrollExtent ??
           (this.hasContentDimensions ? this.minScrollExtent : 0.0),
       maxScrollExtent: maxScrollExtent ?? this.maxScrollExtent,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: infinite_carousel
 description: Carousel in flutter. Supports infinite looping and gives control over anchor and velocity.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/GeekyAnts/infinite-carousel-flutter
 
 environment:


### PR DESCRIPTION
## ScrollPosition code

    @override
     double get minScrollExtent => _minScrollExtent!;
     double? _minScrollExtent;

## my code

    InfiniteCarousel.builder(
                            itemCount: _lfPageStore.realList.length,
                            center: false,
                            controller: _infiniteScrollController,
                            axisDirection: Axis.vertical,
                            loop: _lfPageStore.list.length > 10,
                            itemExtent: 430,
                            itemBuilder: (_, index, __) =>
                                _Row(data: _lfPageStore.realList[index]))
    Row(
        mainAxisAlignment: MainAxisAlignment.spaceBetween,
        children: List.generate(
            data.length,
            (index) => ClipRRect(
                  borderRadius: BorderRadius.circular(10),
                  child: Image(
                    width: 274,
                    height: 400,
                    image: NetworkImage(
                        Config.getFullStaticUrl(data[index].cover)),
                    fit: BoxFit.cover,
                  ),
                )),
      )

## error info

The following _CastError was thrown while resolving an image: 
Null check operator used on a null value